### PR TITLE
revise trema0.3.0 simple-router

### DIFF
--- a/lib/arp-table.rb
+++ b/lib/arp-table.rb
@@ -1,0 +1,55 @@
+class ARPEntry
+  attr_reader :port
+  attr_reader :hwaddr
+  attr_writer :age_max
+
+  def initialize( port, hwaddr, age_max )
+    @port = port
+    @hwaddr = hwaddr
+    @age_max = age_max
+    @last_updated = Time.now
+   p "New entry: MAC addr = #{ @hwaddr.to_s }, port = #{ @port }"
+  end
+
+  def update( port, hwaddr )
+    @port = port
+    @hwaddr = hwaddr
+    @last_updated = Time.now
+    p "Update entry: MAC addr = #{ @hwaddr.to_s }, port = #{ @port }"
+  end
+
+  def aged_out?()
+    aged_out = Time.now - @last_updated > @age_max
+    logger.info "Age out: An ARP entry (MAC address = #{ @hwaddr.to_s }, port number = #{ @port }) has been aged-out" if aged_out
+    aged_out
+  end
+end
+
+
+class ARPTable
+  DEFAULT_AGE_MAX = 300
+
+  def initialize()
+    @db = {}
+  end
+
+  def update( port, ipaddr, hwaddr )
+    entry = @db[ ipaddr.to_i ]
+    if entry
+      entry.update( port, hwaddr )
+    else
+      new_entry = ARPEntry.new( port, hwaddr, DEFAULT_AGE_MAX )
+      @db[ ipaddr.to_i ] = new_entry
+    end
+  end
+
+  def lookup( ipaddr )
+    @db[ ipaddr.to_i ]
+  end
+
+  def age()
+    @db.delete_if do | ipaddr, entry |
+      entry.aged_out?
+    end
+  end
+end

--- a/lib/interface.rb
+++ b/lib/interface.rb
@@ -1,0 +1,65 @@
+require "pio"
+
+require "arp-table"
+require "routing-table"
+
+class Interface
+  attr_reader :hwaddr
+  attr_reader :ipaddr
+  attr_reader :masklen
+  attr_reader :port
+
+  def initialize( options )
+    @port = options[ :port ]
+    @hwaddr = Pio::Mac.new( options[ :hwaddr ] )
+    @ipaddr = Pio::IPv4Address.new( options[ :ipaddr ] )
+    @masklen = options[ :masklen ]
+  end
+
+  def has?( mac )
+    mac == hwaddr
+  end
+end
+
+class Interfaces
+  def initialize interfaces = []
+    @list = []
+    interfaces.each do | each |
+      @list << Interface.new( each )
+    end
+  end
+
+  def find_by_port( port )
+    @list.find do | each |
+      each.port == port
+    end
+  end
+
+  def find_by_ipaddr( ipaddr )
+    @list.find do | each |
+      each.ipaddr == ipaddr
+    end
+  end
+
+  def find_by_prefix( ipaddr )
+    @list.find do | each |
+      masklen = each.masklen
+      each.ipaddr.mask( masklen ) == ipaddr.mask( masklen )
+    end
+  end
+
+  def find_by_port_and_ipaddr( port, ipaddr )
+    @list.find do | each |
+      each.port == port and each.ipaddr == ipaddr
+    end
+  end
+
+  def ours?( port, macda )
+    return true if macda.broadcast?
+
+    interface = find_by_port( port )
+    if not interface.nil? and interface.has?( macda )
+      return true
+    end
+  end
+end

--- a/lib/router-utils.rb
+++ b/lib/router-utils.rb
@@ -1,0 +1,33 @@
+require 'pio'
+
+module RouterUtils
+  def create_arp_request_from( interface, addr )
+    arp_request = Pio::Arp::Request.new( source_mac: interface.hwaddr,
+                                        sender_protocol_address: interface.ipaddr,
+                                        target_protocol_address: addr
+                                       )
+    arp_request.to_binary
+  end
+
+  def create_arp_reply_from( message, replyaddr )
+    arp_reply = Pio::Arp::Reply.new( destination_mac: message.data.source_mac,
+                                    source_mac: replyaddr,
+                                    sender_protocol_address: message.data.target_protocol_address,
+                                    target_protocol_address: message.data.sender_protocol_address
+                                   )
+    arp_reply.to_binary
+  end
+
+  def create_icmpv4_reply( entry, interface, message )
+    icmp_request = Pio::Icmp.read( message.raw_data )
+    icmp_reply = Pio::Icmp::Reply.new( identifier: icmp_request.icmp_identifier,
+                                      source_mac: message.destination_mac,
+                                      destination_mac: message.source_mac,
+                                      ip_destination_address: message.ip_source_address,
+                                      ip_source_address: message.ip_destination_address,
+                                      sequence_number: icmp_request.icmp_sequence_number,
+                                      echo_data: icmp_request.echo_data
+                                     )
+    icmp_reply.to_binary
+  end
+end

--- a/lib/routing-table.rb
+++ b/lib/routing-table.rb
@@ -1,0 +1,35 @@
+require "pio"
+
+class RoutingTable
+  ADDR_LEN = 32
+
+  def initialize( route = [] )
+    @db = Array.new( ADDR_LEN + 1 ) { Hash.new }
+    route.each do | each |
+      add( each )
+    end
+  end
+
+  def add( options )
+    dest = IPAddr.new( options[ :destination ] )
+    masklen = options[ :masklen ]
+    prefix = dest.mask( masklen )
+    @db[ masklen ][ prefix.to_i ] = IPAddr.new( options[ :nexthop ] )
+  end
+
+  def delete( options )
+    dest = IPAddr.new( options[ :destination ] )
+    masklen = options[ :masklen ]
+    prefix = dest.mask( masklen )
+    @db[ masklen ].delete( prefix.to_i )
+  end
+
+  def lookup( dest )
+    ( 0..ADDR_LEN ).reverse_each do | masklen |
+      prefix = dest.mask( masklen )
+      entry = @db[ masklen ][ prefix.to_i ]
+      return entry if entry
+    end
+    nil
+  end
+end

--- a/lib/simple-router.rb
+++ b/lib/simple-router.rb
@@ -1,0 +1,167 @@
+require "pio"
+
+require "arp-table"
+require "interface"
+require "routing-table"
+require "router-utils"
+
+class SimpleRouter < Trema::Controller
+  include RouterUtils
+
+  def start( _args )
+    load "simple_router.conf"
+    @interfaces = Interfaces.new( $interface )
+    @arp_table = ARPTable.new
+    @routing_table = RoutingTable.new( $route )
+  end
+
+  def switch_ready( datapath_id )
+    logger.info "#{datapath_id.to_hex} is connected"
+    @switche = datapath_id
+    init_flows( datapath_id )
+  end
+
+  def packet_in( datapath_id, message )
+    return if not to_me?( message )
+
+    case message.data
+    when Pio::Arp::Request
+      handle_arp_request( datapath_id, message )
+    when Pio::Arp::Reply
+      handle_arp_reply( message )
+    when Pio::Parser::IPv4Packet
+      handle_ipv4( datapath_id, message )
+    else
+      fail 'Failed to handle packet_in data type'
+    end
+  end
+
+  private
+
+  def init_flows( datapath_id )
+    send_flow_mod_delete( datapath_id, match: Match.new() )
+  end
+
+  def to_me?( message )
+    return true if message.destination_mac.broadcast?
+
+    interface = @interfaces.find_by_port( message.in_port )
+    if interface and interface.has?( message.destination_mac )
+      return true
+    end
+  end
+
+  def handle_arp_request( datapath_id, message )
+    port = message.in_port
+    destination_mac = message.data.target_protocol_address
+    interface = @interfaces.find_by_port_and_ipaddr( port, destination_mac )
+    if interface
+      arp_reply = create_arp_reply_from( message, interface.hwaddr )
+      packet_out_raw( datapath_id, arp_reply, SendOutPort.new( interface.port ) )
+    end
+  end
+
+  def handle_arp_reply( message )
+    @arp_table.update( message.in_port,
+                      message.sender_protocol_address,
+                      message.source_mac
+                     )
+  end
+
+  def handle_ipv4( datapath_id, message )
+    if should_forward?( message )
+      forward( datapath_id, message )
+    elsif message.data.ip_protocol == 1
+      icmp = Pio::Icmp.read( message.raw_data )
+      if icmp.icmp_type == 8
+        handle_icmpv4_echo_request( datapath_id, message )
+      else
+        fail "Faild to handle icmp type"
+      end
+    else
+      fail "Faild to handle ipv4 packet"
+    end
+  end
+
+  def should_forward?( message )
+    not @interfaces.find_by_ipaddr( message.data.ip_destination_address )
+  end
+
+  def handle_icmpv4_echo_request( datapath_id, message )
+    interface = @interfaces.find_by_port( message.in_port )
+    ip_source_address = message.data.ip_source_address
+    arp_entry = @arp_table.lookup( ip_source_address )
+    if arp_entry
+      icmpv4_reply = create_icmpv4_reply( arp_entry, interface, message )
+      packet_out_raw( datapath_id, icmpv4_reply, SendOutPort.new( interface.port ) )
+    else
+      handle_unresolved_packet( datapath_id, message, interface, ip_source_address )
+    end
+  end
+
+  def forward( datapath_id, message )
+    next_hop = resolve_next_hop( message.data.ip_destination_address )
+
+    interface = @interfaces.find_by_prefix( next_hop )
+    if not interface or interface.port == message.in_port
+      return
+    end
+
+    arp_entry = @arp_table.lookup( next_hop )
+    if arp_entry
+      macsa = interface.hwaddr
+      macda = arp_entry.hwaddr
+      action = create_action_from( macsa, macda, interface.port )
+      flow_mod( datapath_id, message, action )
+      packet_out( datapath_id, message, action )
+    else
+      handle_unresolved_packet( datapath_id, message, interface, next_hop )
+    end
+  end
+
+  def resolve_next_hop( ip_destination_address )
+    interface = @interfaces.find_by_prefix( ip_destination_address )
+    if interface
+      ip_destination_address
+    else
+      @routing_table.lookup( ip_destination_address )
+    end
+  end
+
+  def flow_mod( datapath_id, message, action )
+    send_flow_mod_add(
+      datapath_id,
+      match: ExactMatch.new( message ),
+      actions: action
+    )
+  end
+
+  def packet_out( datapath_id, packet, action )
+    send_packet_out(
+      datapath_id,
+      packet_in: packet,
+      actions: action
+    )
+  end
+
+  def packet_out_raw( datapath_id, raw_data, action )
+    send_packet_out(
+      datapath_id,
+      raw_data: raw_data,
+      actions: action
+    )
+  end
+
+  def handle_unresolved_packet( datapath_id, message, interface, ipaddr )
+    arp_request = create_arp_request_from( interface, ipaddr )
+    packet_out_raw( datapath_id, arp_request, SendOutPort.new( interface.port ) )
+  end
+
+  def create_action_from( source_mac, destination_mac, port )
+    [
+      SetEtherSourceAddress.new( source_mac ),
+      SetEtherDestinationAddress.new( destination_mac ),
+      SendOutPort.new( port )
+    ]
+  end
+end

--- a/lib/simple_router.conf
+++ b/lib/simple_router.conf
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+$interface = [
+  {
+    :port => 1,
+    :hwaddr => "00:00:00:01:00:01",
+    :ipaddr => "192.168.122.1",
+    :masklen => 24
+  },
+  {
+    :port => 2,
+    :hwaddr => "00:00:00:01:00:02",
+    :ipaddr => "192.168.123.1",
+    :masklen => 24
+  }
+]
+
+$route = [
+  {
+    :destination => "0.0.0.0",
+    :masklen => 0,
+    :nexthop => "192.168.122.2"
+  }
+]


### PR DESCRIPTION
trema 0.3.0 にあった src/examples/simple-router を trema 0.7.1 で動くように書き換えました。

エミュレート用の設定ファイル以外は、元の機能とほぼ同じです。
独自に追加した点は以下になります。
- openflowスイッチとの接続時にスイッチのフローを初期化（すべて消去）するようにしました

``` rb
def switch_ready( datapath_id )   
  logger.info "#{datapath_id.to_hex} is connected"  
  @switche = datapath_id                                                                               
  init_flows( datapath_id )  
end
```

``` rb
def init_flows( datapath_id )
  send_flow_mod_delete( datapath_id, match: Match.new() )                                              
end
```
